### PR TITLE
Allow to override general configuration

### DIFF
--- a/Service/Html2pdf.php
+++ b/Service/Html2pdf.php
@@ -9,6 +9,7 @@ class Html2pdf
     public $format;
     public $lang;
     public $unicode;
+    public $encoding;
     public $margin;
 
     public function __construct($mode, $format, $lang, $unicode, $encoding, $margin)
@@ -18,6 +19,7 @@ class Html2pdf
     	$this->lang = $lang;
     	$this->unicode = $unicode;
     	$this->margin = $margin;
+    	$this->encoding = $encoding;
     }
 
     public function get()


### PR DESCRIPTION
Hi,

Once the parameters (mode, format, lang...) have been defined in the services.yml, you cannot change them dynamically.

And the object returned by the get() method (instance of HTML2PDF) has no setters for these parameters.

Thus you cannot have multiple PDF with different configuration.

This simple PR allow to set specific mode/format/lang... to PDF before getting it
